### PR TITLE
COMPASS-3294: Simplify operator snippets

### DIFF
--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -11,7 +11,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Adds new fields to documents.',
     comment: '/**\n * newField - The new field name.\n * expression - The new field expression.\n */\n',
-    snippet: '{\n  ${1:<<newField>>}: ${2:<<expression>>}\n}'
+    snippet: '{\n  ${1:newField}: ${2:expression}\n}'
   },
   {
     name: '$bucket',
@@ -22,7 +22,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Categorizes incoming documents into groups, called buckets, based on a specified expression and bucket boundaries.',
     comment: '/**\n * expression: The expression to group by.\n * lowerbound: The first bucket boundary.\n * literal: Optional default _id.\n * output1: Optional output name.\n * accumulator: Optional output expression.\n */\n',
-    snippet: '{\n  groupBy: ${1:<<expression>>},\n  boundaries: [ ${2:<<lowerbound>>}, ${3:...} ],\n  default: ${4:<<literal>>},\n  output: {\n     ${5:<<output1>>}: { ${6:<<accumulator>>} }, ${7:...}\n  }\n}'
+    snippet: '{\n  groupBy: ${1:expression},\n  boundaries: [ ${2:lowerbound}, ${3:...} ],\n  default: ${4:literal},\n  output: {\n     ${5:output1}: { ${6:accumulator} }, ${7:...}\n  }\n}'
   },
   {
     name: '$bucketAuto',
@@ -33,7 +33,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Categorizes incoming documents into a specific number of groups, called buckets, based on a specified expression. Bucket boundaries are automatically determined in an attempt to evenly distribute the documents into the specified number of buckets.',
     comment: '/**\n * expression - The group by expression.\n * buckets: The number of buckets.\n * output1: Optional output field name.\n * accumulator: Optional output expression.\n * granularity - Optional number series.\n */\n',
-    snippet: '{\n  groupBy: ${1:<<expression>>},\n  buckets: ${2:<<number>>},\n  output: {\n    ${3:<<output1>>}: ${4:<<accumulator>>}, ${5:...}\n  },\n  granularity: \'${6:<<string>>}\'\n}'
+    snippet: '{\n  groupBy: ${1:expression},\n  buckets: ${2:number},\n  output: {\n    ${3:output1}: ${4:accumulator}, ${5:...}\n  },\n  granularity: \'${6:string}\'\n}'
   },
   {
     name: '$collStats',
@@ -44,7 +44,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Returns statistics regarding a collection or view.',
     comment: '/**\n * histograms - Optional latency histograms.\n * storageStats - Optional storage stats.\n*/\n',
-    snippet: '{\n  latencyStats: {\n    histograms: ${1:<<boolean>>}\n  },\n  storageStats: {${2:}},\n}'
+    snippet: '{\n  latencyStats: {\n    histograms: ${1:boolean}\n  },\n  storageStats: {${2:}},\n}'
   },
   {
     name: '$count',
@@ -55,7 +55,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Returns a count of the number of documents at this stage of the aggregation pipeline.',
     comment: '/**\n * Provide the field name for the count.\n */\n',
-    snippet: '\'${1:<<string>>}\''
+    snippet: '\'${1:string}\''
   },
   {
     name: '$facet',
@@ -66,7 +66,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Processes multiple aggregation pipelines within a single stage on the same set of input documents.',
     comment: '/**\n * outputField1 - The first output field.\n * stage1 - The first aggregation stage.\n */\n',
-    snippet: '{\n  ${1:<<outputField1>>}: [ ${2:<<stage1>>}, ${3:...} ]\n}'
+    snippet: '{\n  ${1:outputField1}: [ ${2:stage1}, ${3:...} ]\n}'
   },
   {
     name: '$geoNear',
@@ -77,7 +77,7 @@ const STAGE_OPERATORS = [
     version: '2.4.0',
     description: 'Returns an ordered stream of documents based on the proximity to a geospatial point.',
     comment: '/**\n * options - The geo query options.\n */\n',
-    snippet: '{\n  ${1:<<options>>}\n}'
+    snippet: '{\n  ${1:options}\n}'
   },
   {
     name: '$graphLookup',
@@ -88,13 +88,13 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Performs a recursive search on a collection.',
     comment: '/**\n * from - The target collection.\n * startWith - Expression to start.\n * connectFromField - Field to connect.\n * connectToField - Field to connect to.\n * as - Name of the array field.\n * maxDepth - Optional max recursion depth.\n * depthField - Optional Name of the depth field.\n * restrictSearchWithMatch - Optional query.\n */\n',
-    snippet: '{\n  from: \'${1:<<string>>}\',\n' +
-    '  startWith: ${2:<<expression>>},\n' +
-    '  connectFromField: \'${3:<<string>>}\',\n' +
-    '  connectToField: \'${4:<<string>>}\',\n' +
-    '  as: \'${5:<<string>>}\',\n' +
-    '  maxDepth: ${6:<<number>>},\n' +
-    '  depthField: \'${7:<<string>>}\',\n' +
+    snippet: '{\n  from: \'${1:string}\',\n' +
+    '  startWith: ${2:expression},\n' +
+    '  connectFromField: \'${3:string}\',\n' +
+    '  connectToField: \'${4:string}\',\n' +
+    '  as: \'${5:string}\',\n' +
+    '  maxDepth: ${6:number},\n' +
+    '  depthField: \'${7:string}\',\n' +
     '  restrictSearchWithMatch: {${8}}\n}'
   },
   {
@@ -106,7 +106,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Groups input documents by a specified identifier expression and applies the accumulator expression(s), if specified, to each group.',
     comment: '/**\n * _id - The id of the group.\n * field1 - The first field name.\n */\n',
-    snippet: '{\n  _id: ${1:<<expression>>},\n  ${2:<<field1>>}: {\n    ${3:<<accumulator1>>}: ${4:<<expression1>>}\n  }\n}'
+    snippet: '{\n  _id: ${1:expression},\n  ${2:field1}: {\n    ${3:accumulator1}: ${4:expression1}\n  }\n}'
   },
   {
     name: '$indexStats',
@@ -128,7 +128,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Passes the first n documents unmodified to the pipeline where n is the specified limit.',
     comment: '/**\n * Provide the number of documents to limit.\n */\n',
-    snippet: '${1:<<number>>}'
+    snippet: '${1:number}'
   },
   {
     name: '$lookup',
@@ -139,10 +139,10 @@ const STAGE_OPERATORS = [
     version: '3.2.0',
     description: 'Performs a left outer join to another collection in the same database to filter in documents from the “joined” collection for processing.',
     comment: '/**\n * from - The target collection.\n * localField - The local join field.\n * foreignField - The target join field.\n * as - The name for the results.\n */\n',
-    snippet: '{\n  from: \'${1:<<string>>}\',\n' +
-    '  localField: \'${2:<<string>>}\',\n' +
-    '  foreignField: \'${3:<<string>>}\',\n' +
-    '  as: \'${4:<<string>>}\'\n}'
+    snippet: '{\n  from: \'${1:string}\',\n' +
+    '  localField: \'${2:string}\',\n' +
+    '  foreignField: \'${3:string}\',\n' +
+    '  as: \'${4:string}\'\n}'
   },
   {
     name: '$match',
@@ -153,7 +153,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Filters the document stream to allow only matching documents to pass unmodified into the next pipeline stage.',
     comment: '/**\n * query - The query in MQL.\n */\n',
-    snippet: '{\n  ${1:<<query>>}\n}'
+    snippet: '{\n  ${1:query}\n}'
   },
   {
     name: '$out',
@@ -164,7 +164,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Writes the resulting documents of the aggregation pipeline to a collection.',
     comment: '/**\n * Provide the name of the output collection.\n */\n',
-    snippet: '\'${1:<<string>>}\''
+    snippet: '\'${1:string}\''
   },
   {
     name: '$project',
@@ -175,7 +175,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Reshapes each document in the stream, such as by adding new fields or removing existing fields.',
     comment: '/**\n * specifications - The fields to\n *   include or exclude.\n */\n',
-    snippet: '{\n  ${1:<<specification(s)>>}\n}'
+    snippet: '{\n  ${1:specification(s)}\n}'
   },
   {
     name: '$redact',
@@ -186,7 +186,7 @@ const STAGE_OPERATORS = [
     version: '2.6.0',
     description: 'Reshapes each document in the stream by restricting the content for each document based on information stored in the documents themselves.',
     comment: '/**\n * expression - Any valid expression that\n *   evaluates to $$DESCEND, $$PRUNE, or $$KEEP.\n */\n',
-    snippet: '{\n  ${1:<<expression>>}\n}'
+    snippet: '{\n  ${1:expression}\n}'
   },
   {
     name: '$replaceRoot',
@@ -197,7 +197,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Replaces a document with the specified embedded document.',
     comment: '/**\n * replacementDocument - A document or string.\n */\n',
-    snippet: '{\n  newRoot: ${1:<<<replacementDocument>>}\n}'
+    snippet: '{\n  newRoot: ${1:<replacementDocument}\n}'
   },
   {
     name: '$sample',
@@ -208,7 +208,7 @@ const STAGE_OPERATORS = [
     version: '3.2.0',
     description: 'Randomly selects the specified number of documents from its input.',
     comment: '/**\n * size - The number of documents to sample.\n */\n',
-    snippet: '{\n  size: ${1:<<number>>}\n}'
+    snippet: '{\n  size: ${1:number}\n}'
   },
   {
     name: '$skip',
@@ -219,7 +219,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Skips the first n documents where n is the specified skip number and passes the remaining documents unmodified to the pipeline.',
     comment: '/**\n * Provide the number of documents to skip.\n */\n',
-    snippet: '${1:<<number>>}'
+    snippet: '${1:number}'
   },
   {
     name: '$sort',
@@ -230,7 +230,7 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Reorders the document stream by a specified sort key.',
     comment: '/**\n * Provide any number of field/order pairs.\n */\n',
-    snippet: '{\n  ${1:<<field1>>}: ${2:<<sortOrder>>}\n}'
+    snippet: '{\n  ${1:field1}: ${2:sortOrder}\n}'
   },
   {
     name: '$sortByCount',
@@ -241,7 +241,7 @@ const STAGE_OPERATORS = [
     version: '3.4.0',
     description: 'Groups incoming documents based on the value of a specified expression, then computes the count of documents in each distinct group.',
     comment: '/**\n * expression - Grouping expression or string.\n */\n',
-    snippet: '{\n  ${1:<<expression>>}\n}'
+    snippet: '{\n  ${1:expression}\n}'
   },
   {
     name: '$unwind',
@@ -252,9 +252,9 @@ const STAGE_OPERATORS = [
     version: '2.2.0',
     description: 'Deconstructs an array field from the input documents to output a document for each element.',
     comment: '/**\n * path - Path to the array field.\n * includeArrayIndex - Optional name for index.\n * preserveNullAndEmptyArrays - Optional\n *   toggle to unwind null and empty values.\n */\n',
-    snippet: '{\n  path: ${1:<<path>>},\n' +
-    '  includeArrayIndex: \'${2:<<string>>}\',\n' +
-    '  preserveNullAndEmptyArrays: ${3:<<boolean>>}\n}'
+    snippet: '{\n  path: ${1:path},\n' +
+    '  includeArrayIndex: \'${2:string}\',\n' +
+    '  preserveNullAndEmptyArrays: ${3:boolean}\n}'
   }
 ];
 


### PR DESCRIPTION
Autopoulate with just the `varname` instead of `<<varname>>`. For example, `query` instead of `<<query>>`

![simplify-ace-snippets](https://user-images.githubusercontent.com/23074/50234255-441f1e80-0383-11e9-9735-58bda28b3456.gif)

## Customizing Editor Styling

![screenshot 2018-12-20 10 05 38](https://user-images.githubusercontent.com/23074/50292385-fa940980-043e-11e9-973d-87202597c2fb.png)

These visual elements are all referred to as markers/decorations/etc. You can find them in the DOM via devtools under `div.ace_marker-layer`. 

The CSS classes to change styling:

- `.ace_selected-word` red border above
- `.ace_selection` red background above
- `.ace_snippet-marker` green background above
- `.ace_active-line` no show above but easy to highlight current cursor line w/ bg color

*Discussion from Slack*

> I'm not sure, it makes it look less like a placeholder, but maybe it's just my feeling. @here what do you guys think? @joy considering what users said during the interview, would you go for this option?
> 
> joy [1 hour ago]
Users would love if we could remove ‘<<>>’. Agree with you that it won’t look like a placeholder.. but I’d be willing to test with users to see how it fares
> 
> max [1 hour ago]
> I'm assuming there is no way to make the placeholders of a different color, as they are just words and > there are no rules in the grammar to treat them differently, right?

## Other interesting things

### vscode

> Hover over an object shows a tooltip with the schema of the underlying object

![screenshot 2018-12-20 14 19 32](https://user-images.githubusercontent.com/23074/50309885-6477d780-046e-11e9-8deb-4f0d73eddfb2.png)

### codemirror devtools

> To show error messages and/or warnings, present in context of the code. Here the red squiggle + red x shows that an error occurred  *in this method definition*.

![screenshot 2018-12-20 14 38 42](https://user-images.githubusercontent.com/23074/50309924-7fe2e280-046e-11e9-9f9b-284dd90a16bc.png)

