### PR TITLE
COMPASS-3153 Add jsonSchema to ace-autocompleter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 module.exports = require('./lib/query-autocompleter');
 module.exports.QueryAutoCompleter = require('./lib/query-autocompleter');
 module.exports.StageAutoCompleter = require('./lib/stage-autocompleter');
+module.exports.ValidationAutoCompleter = require('./lib/validation-autocompleter');
 module.exports.ACCUMULATORS = require('./lib/constants/accumulators');
 module.exports.BSON_TYPES = require('./lib/constants/bson-types');
 module.exports.EXPRESSION_OPERATORS = require('./lib/constants/expression-operators');
 module.exports.QUERY_OPERATORS = require('./lib/constants/query-operators');
 module.exports.STAGE_OPERATORS = require('./lib/constants/stage-operators');
+module.exports.JSON_SCHEMA = require('./lib/constants/json-schema');

--- a/lib/constants/json-schema.js
+++ b/lib/constants/json-schema.js
@@ -1,0 +1,268 @@
+/**
+ * The JSON Schema properties.
+ */
+const JSON_SCHEMA = [
+  {
+    name: 'bsonType',
+    value: 'bsonType',
+    label: 'bsonType',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Accepts same string aliases used for the $type operator'
+  },
+  {
+    name: 'enum',
+    value: 'enum',
+    label: 'enum',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Enumerates all possible values of the field'
+  },
+  {
+    name: 'type',
+    value: 'type',
+    label: 'type',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Enumerates the possible JSON types of the field'
+  },
+  {
+    name: 'allOf',
+    value: 'allOf',
+    label: 'allOf',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Field must match all specified schemas'
+  },
+  {
+    name: 'anyOf',
+    value: 'anyOf',
+    label: 'anyOf',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Field must match at least one of the specified schemas'
+  },
+  {
+    name: 'oneOf',
+    value: 'oneOf',
+    label: 'oneOf',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Field must match exactly one of the specified schemas'
+  },
+  {
+    name: 'not',
+    value: 'not',
+    label: 'not',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Field must not match the schema'
+  },
+  {
+    name: 'multipleOf',
+    value: 'multipleOf',
+    label: 'multipleOf',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Field must be a multiple of this value'
+  },
+  {
+    name: 'maximum',
+    value: 'maximum',
+    label: 'maximum',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the maximum value of the field'
+  },
+  {
+    name: 'exclusiveMaximum',
+    value: 'exclusiveMaximum',
+    label: 'exclusiveMaximum',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'If true and field is a number, maximum is an exclusive maximum'
+  },
+  {
+    name: 'minimum',
+    value: 'minimum',
+    label: 'minimum',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the minimum value of the field'
+  },
+  {
+    name: 'exclusiveMinimum',
+    value: 'exclusiveMinimum',
+    label: 'exclusiveMinimum',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'If true, minimum is an exclusive minimum'
+  },
+  {
+    name: 'maxLength',
+    value: 'maxLength',
+    label: 'maxLength',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the maximum length of the field'
+  },
+  {
+    name: 'minLength',
+    value: 'minLength',
+    label: 'minLength',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the minimum length of the field'
+  },
+  {
+    name: 'pattern',
+    value: 'pattern',
+    label: 'pattern',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Field must match the regular expression'
+  },
+  {
+    name: 'maxProperties',
+    value: 'maxProperties',
+    label: 'maxProperties',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the field’s maximum number of properties'
+  },
+  {
+    name: 'minProperties',
+    value: 'minProperties',
+    label: 'minProperties',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the field’s minimum number of properties'
+  },
+  {
+    name: 'required',
+    value: 'required',
+    label: 'required',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Object’s property set must contain all the specified elements in the array'
+  },
+  {
+    name: 'additionalProperties',
+    value: 'additionalProperties',
+    label: 'additionalProperties',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'If true, additional fields are allowed'
+  },
+  {
+    name: 'properties',
+    value: 'properties',
+    label: 'properties',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'A valid JSON Schema where each value is also a valid JSON Schema object'
+  },
+  {
+    name: 'patternProperties',
+    value: 'patternProperties',
+    label: 'patternProperties',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'In addition to properties requirements, each property name of this object must be a valid regular expression'
+  },
+  {
+    name: 'dependencies',
+    value: 'dependencies',
+    label: 'dependencies',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Describes field or schema dependencies'
+  },
+  {
+    name: 'additionalItems',
+    value: 'additionalItems',
+    label: 'additionalItems',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'If an object, must be a valid JSON Schema'
+  },
+  {
+    name: 'items',
+    value: 'items',
+    label: 'items',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Must be either a valid JSON Schema, or an array of valid JSON Schemas'
+  },
+  {
+    name: 'maxItems',
+    value: 'maxItems',
+    label: 'maxItems',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the maximum length of array'
+  },
+  {
+    name: 'minItems',
+    value: 'minItems',
+    label: 'minItems',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'Indicates the minimum length of array'
+  },
+  {
+    name: 'uniqueItems',
+    value: 'uniqueItems',
+    label: 'uniqueItems',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'If true, each item in the array must be unique'
+  },
+  {
+    name: 'title',
+    value: 'title',
+    label: 'title',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'A descriptive title string with no effect'
+  },
+  {
+    name: 'description',
+    value: 'description',
+    label: 'description',
+    score: 1,
+    meta: 'json-schema',
+    version: '0.0.0',
+    description: 'A string that describes the schema and has no effect.'
+  }
+];
+
+module.exports = JSON_SCHEMA;

--- a/lib/constants/json-schema.js
+++ b/lib/constants/json-schema.js
@@ -8,7 +8,7 @@ const JSON_SCHEMA = [
     label: 'bsonType',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Accepts same string aliases used for the $type operator'
   },
   {
@@ -17,7 +17,7 @@ const JSON_SCHEMA = [
     label: 'enum',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Enumerates all possible values of the field'
   },
   {
@@ -26,7 +26,7 @@ const JSON_SCHEMA = [
     label: 'type',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Enumerates the possible JSON types of the field'
   },
   {
@@ -35,7 +35,7 @@ const JSON_SCHEMA = [
     label: 'allOf',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Field must match all specified schemas'
   },
   {
@@ -44,7 +44,7 @@ const JSON_SCHEMA = [
     label: 'anyOf',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Field must match at least one of the specified schemas'
   },
   {
@@ -53,7 +53,7 @@ const JSON_SCHEMA = [
     label: 'oneOf',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Field must match exactly one of the specified schemas'
   },
   {
@@ -62,7 +62,7 @@ const JSON_SCHEMA = [
     label: 'not',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Field must not match the schema'
   },
   {
@@ -71,7 +71,7 @@ const JSON_SCHEMA = [
     label: 'multipleOf',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Field must be a multiple of this value'
   },
   {
@@ -80,7 +80,7 @@ const JSON_SCHEMA = [
     label: 'maximum',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the maximum value of the field'
   },
   {
@@ -89,7 +89,7 @@ const JSON_SCHEMA = [
     label: 'exclusiveMaximum',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'If true and field is a number, maximum is an exclusive maximum'
   },
   {
@@ -98,7 +98,7 @@ const JSON_SCHEMA = [
     label: 'minimum',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the minimum value of the field'
   },
   {
@@ -107,7 +107,7 @@ const JSON_SCHEMA = [
     label: 'exclusiveMinimum',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'If true, minimum is an exclusive minimum'
   },
   {
@@ -116,7 +116,7 @@ const JSON_SCHEMA = [
     label: 'maxLength',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the maximum length of the field'
   },
   {
@@ -125,7 +125,7 @@ const JSON_SCHEMA = [
     label: 'minLength',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the minimum length of the field'
   },
   {
@@ -134,7 +134,7 @@ const JSON_SCHEMA = [
     label: 'pattern',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Field must match the regular expression'
   },
   {
@@ -143,7 +143,7 @@ const JSON_SCHEMA = [
     label: 'maxProperties',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the field’s maximum number of properties'
   },
   {
@@ -152,7 +152,7 @@ const JSON_SCHEMA = [
     label: 'minProperties',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the field’s minimum number of properties'
   },
   {
@@ -161,7 +161,7 @@ const JSON_SCHEMA = [
     label: 'required',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Object’s property set must contain all the specified elements in the array'
   },
   {
@@ -170,7 +170,7 @@ const JSON_SCHEMA = [
     label: 'additionalProperties',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'If true, additional fields are allowed'
   },
   {
@@ -179,7 +179,7 @@ const JSON_SCHEMA = [
     label: 'properties',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'A valid JSON Schema where each value is also a valid JSON Schema object'
   },
   {
@@ -188,7 +188,7 @@ const JSON_SCHEMA = [
     label: 'patternProperties',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'In addition to properties requirements, each property name of this object must be a valid regular expression'
   },
   {
@@ -197,7 +197,7 @@ const JSON_SCHEMA = [
     label: 'dependencies',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Describes field or schema dependencies'
   },
   {
@@ -206,7 +206,7 @@ const JSON_SCHEMA = [
     label: 'additionalItems',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'If an object, must be a valid JSON Schema'
   },
   {
@@ -215,7 +215,7 @@ const JSON_SCHEMA = [
     label: 'items',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Must be either a valid JSON Schema, or an array of valid JSON Schemas'
   },
   {
@@ -224,7 +224,7 @@ const JSON_SCHEMA = [
     label: 'maxItems',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the maximum length of array'
   },
   {
@@ -233,7 +233,7 @@ const JSON_SCHEMA = [
     label: 'minItems',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'Indicates the minimum length of array'
   },
   {
@@ -242,7 +242,7 @@ const JSON_SCHEMA = [
     label: 'uniqueItems',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'If true, each item in the array must be unique'
   },
   {
@@ -251,7 +251,7 @@ const JSON_SCHEMA = [
     label: 'title',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'A descriptive title string with no effect'
   },
   {
@@ -260,7 +260,7 @@ const JSON_SCHEMA = [
     label: 'description',
     score: 1,
     meta: 'json-schema',
-    version: '0.0.0',
+    version: '3.6.0',
     description: 'A string that describes the schema and has no effect.'
   }
 ];

--- a/lib/validation-autocompleter.js
+++ b/lib/validation-autocompleter.js
@@ -1,0 +1,70 @@
+const QUERY_OPERATORS = require('./constants/query-operators');
+const BSON_TYPES = require('./constants/bson-types');
+const JSON_SCHEMA = require('./constants/json-schema');
+const filter = require('./filter');
+
+/**
+ * String token type.
+ */
+const STRING = 'string';
+
+/**
+ * The match completions.
+ */
+const MATCH_COMPLETIONS = QUERY_OPERATORS.concat(BSON_TYPES);
+
+/**
+ * Adds autocomplete suggestions for validation queries.
+ */
+class ValidationAutoCompleter {
+
+  /**
+   * Instantiate a new completer.
+   *
+   * @param {String} version - The version.
+   * @param {TextCompleter} textCompleter - The fallback Ace text completer.
+   * @param {Array} fields - The collection fields.
+   */
+  constructor(version, textCompleter, fields) {
+    this.version = version;
+    this.textCompleter = textCompleter;
+    this.fields = fields;
+  }
+
+  /**
+   * Update the autocompleter with new fields.
+   *
+   * @param {Array} fields - The new fields.
+   */
+  update(fields) {
+    this.fields = fields;
+  }
+
+  /**
+   * Get the completion list for the provided params.
+   *
+   * @param {Editor} editor - The ACE editor.
+   * @param {EditSession} session - The current editor session.
+   * @param {Position} position - The cursor position.
+   * @param {String} prefix - The string prefix to complete.
+   * @param {Function} done - The done callback.
+   *
+   * @returns {Function} The completion function.
+   */
+  getCompletions(editor, session, position, prefix, done) {
+    // Empty prefixes do not return results.
+    if (prefix === '') return done(null, []);
+    // If the current token is a string with single or double quotes, then
+    // we want to suggest document fields instead of suggesting operators.
+    const currentToken = session.getTokenAt(position.row, position.column);
+    if (currentToken.type === STRING) {
+      return done(null, this.fields);
+    }
+    // If the current token is not a string, then we proceed as normal to suggest
+    // operators to the user.
+    const expressions = MATCH_COMPLETIONS.concat(this.fields, JSON_SCHEMA);
+    return done(null, filter(this.version, expressions, prefix));
+  }
+}
+
+module.exports = ValidationAutoCompleter;

--- a/test/validation-autocompleter.test.js
+++ b/test/validation-autocompleter.test.js
@@ -201,9 +201,9 @@ describe('ValidationAutoCompleter', () => {
       });
 
       context('when query contains $jsonSchema', () => {
-        const completer = new ValidationAutoCompleter('3.4.0', textCompleter, fields);
-        const session = new EditSession('{ $jsonSchema: {  } }', new Mode());
-        const position = { row: 0, column: 2 };
+        const completer = new ValidationAutoCompleter('3.6.0', textCompleter, fields);
+        const session = new EditSession('{ $jsonSchema: { t } }', new Mode());
+        const position = { row: 0, column: 18 };
 
         it('returns all the query operators', () => {
           completer.getCompletions(editor, session, position, 't', (error, results) => {
@@ -215,7 +215,7 @@ describe('ValidationAutoCompleter', () => {
                 label: 'type',
                 score: 1,
                 meta: 'json-schema',
-                version: '0.0.0',
+                version: '3.6.0',
                 description: 'Enumerates the possible JSON types of the field'
               },
               {
@@ -224,7 +224,7 @@ describe('ValidationAutoCompleter', () => {
                 label: 'title',
                 score: 1,
                 meta: 'json-schema',
-                version: '0.0.0',
+                version: '3.6.0',
                 description: 'A descriptive title string with no effect'
               }
             ]);

--- a/test/validation-autocompleter.test.js
+++ b/test/validation-autocompleter.test.js
@@ -1,0 +1,236 @@
+const { EditSession } = require('brace');
+const ace = require('brace');
+const { ValidationAutoCompleter, QUERY_OPERATORS } = require('../');
+
+require('brace/mode/javascript');
+require('brace/ext/language_tools');
+
+const { Mode } = ace.acequire('ace/mode/javascript');
+const { textCompleter } = ace.acequire('ace/ext/language_tools');
+
+describe('ValidationAutoCompleter', () => {
+  const fields = [
+    {
+      name: 'name',
+      value: 'name',
+      score: 1,
+      meta: 'field',
+      version: '0.0.0'
+    },
+    {
+      name: 'name.first',
+      value: 'name.first',
+      score: 1,
+      meta: 'field',
+      version: '0.0.0'
+    }
+  ];
+  const editor = sinon.spy();
+
+  describe('#getCompletions', () => {
+    context('when fields is null', () => {
+      const completer = new ValidationAutoCompleter('3.4.0', textCompleter, null);
+      const session = new EditSession('', new Mode());
+      const position = { row: 0, column: 0 };
+
+      it('returns no results', () => {
+        completer.getCompletions(editor, session, position, '', (error, results) => {
+          expect(error).to.equal(null);
+          expect(results).to.deep.equal([]);
+        });
+      });
+    });
+
+    context('when the fields are empty', () => {
+      const completer = new ValidationAutoCompleter('3.4.0', textCompleter, []);
+      const session = new EditSession('', new Mode());
+      const position = { row: 0, column: 0 };
+
+      it('returns no results', () => {
+        completer.getCompletions(editor, session, position, '', (error, results) => {
+          expect(error).to.equal(null);
+          expect(results).to.deep.equal([]);
+        });
+      });
+    });
+
+    context('when the current token is a string', () => {
+      context('when there are no previous autocompletions', () => {
+        const completer = new ValidationAutoCompleter('3.4.0', textCompleter, fields);
+        const session = new EditSession('', new Mode());
+        const position = { row: 0, column: 0 };
+
+        it('returns no results', () => {
+          completer.getCompletions(editor, session, position, '', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results).to.deep.equal([]);
+          });
+        });
+      });
+
+      context('when the string is a $', () => {
+        const completer = new ValidationAutoCompleter('3.6.0', textCompleter, fields);
+        const session = new EditSession('{ $ }', new Mode());
+        const position = { row: 0, column: 2 };
+
+        it('returns all the query operators', () => {
+          completer.getCompletions(editor, session, position, '$', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results).to.deep.equal(QUERY_OPERATORS);
+          });
+        });
+      });
+
+      context('when the string is $a', () => {
+        const completer = new ValidationAutoCompleter('3.6.0', textCompleter, fields);
+        const session = new EditSession('{ $a }', new Mode());
+        const position = { row: 0, column: 3 };
+
+        it('returns all the matching query operators', () => {
+          completer.getCompletions(editor, session, position, '$a', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results).to.deep.equal([
+              {
+                name: '$all',
+                value: '$all',
+                score: 1,
+                meta: 'query',
+                version: '2.2.0'
+              },
+              {
+                name: '$and',
+                value: '$and',
+                score: 1,
+                meta: 'query',
+                version: '2.2.0'
+              }
+            ]);
+          });
+        });
+      });
+
+      context('when the string matches a bson type', () => {
+        const completer = new ValidationAutoCompleter('3.6.0', textCompleter, fields);
+        const session = new EditSession('{ N }', new Mode());
+        const position = { row: 0, column: 2 };
+
+        it('returns all the matching query operators', () => {
+          completer.getCompletions(editor, session, position, 'N', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results).to.deep.equal([
+              {
+                name: 'NumberInt',
+                value: 'NumberInt',
+                label: 'NumberInt',
+                score: 1,
+                meta: 'bson',
+                version: '0.0.0',
+                description: 'BSON 32 bit Integer type',
+                snippet: 'NumberInt(${1:value})'
+              },
+              {
+                name: 'NumberLong',
+                value: 'NumberLong',
+                label: 'NumberLong',
+                score: 1,
+                meta: 'bson',
+                version: '0.0.0',
+                description: 'BSON 64 but Integer type',
+                snippet: 'NumberLong(${1:value})'
+              },
+              {
+                name: 'NumberDecimal',
+                value: 'NumberDecimal',
+                label: 'NumberDecimal',
+                score: 1,
+                meta: 'bson',
+                version: '3.4.0',
+                description: 'BSON Decimal128 type',
+                snippet: "NumberDecimal('${1:value}')"
+              }
+            ]);
+          });
+        });
+      });
+
+      context('when the version doesnt match all operators', () => {
+        const completer = new ValidationAutoCompleter('3.4.0', textCompleter, fields);
+        const session = new EditSession('{ $ }', new Mode());
+        const position = { row: 0, column: 2 };
+
+        it('returns all the query operators', () => {
+          completer.getCompletions(editor, session, position, '$', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results.length).to.equal(QUERY_OPERATORS.length - 2);
+          });
+        });
+      });
+
+      context('when the version doesnt match a bson type', () => {
+        const completer = new ValidationAutoCompleter('3.2.0', textCompleter, fields);
+        const session = new EditSession('{ N }', new Mode());
+        const position = { row: 0, column: 2 };
+
+        it('returns all the query operators', () => {
+          completer.getCompletions(editor, session, position, 'N', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results).to.deep.equal([
+              {
+                name: 'NumberInt',
+                value: 'NumberInt',
+                label: 'NumberInt',
+                score: 1,
+                meta: 'bson',
+                version: '0.0.0',
+                description: 'BSON 32 bit Integer type',
+                snippet: 'NumberInt(${1:value})'
+              },
+              {
+                name: 'NumberLong',
+                value: 'NumberLong',
+                label: 'NumberLong',
+                score: 1,
+                meta: 'bson',
+                version: '0.0.0',
+                description: 'BSON 64 but Integer type',
+                snippet: 'NumberLong(${1:value})'
+              }
+            ]);
+          });
+        });
+      });
+
+      context('when query contains $jsonSchema', () => {
+        const completer = new ValidationAutoCompleter('3.4.0', textCompleter, fields);
+        const session = new EditSession('{ $jsonSchema: {  } }', new Mode());
+        const position = { row: 0, column: 2 };
+
+        it('returns all the query operators', () => {
+          completer.getCompletions(editor, session, position, 't', (error, results) => {
+            expect(error).to.equal(null);
+            expect(results).to.deep.equal([
+              {
+                name: 'type',
+                value: 'type',
+                label: 'type',
+                score: 1,
+                meta: 'json-schema',
+                version: '0.0.0',
+                description: 'Enumerates the possible JSON types of the field'
+              },
+              {
+                name: 'title',
+                value: 'title',
+                label: 'title',
+                score: 1,
+                meta: 'json-schema',
+                version: '0.0.0',
+                description: 'A descriptive title string with no effect'
+              }
+            ]);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Ace-autocompleter should suggest $jsonSchema properties. $jsonSchema is part of a query, but since QueryAutoCompleter also used by StageAutoCompleter, to not affect agg pipeline builder, new ValidationAutoCompleter was created. It provides access to $jsonSchema properties and also suggests fields when user types inside single or double quotes (according to the design).