### PR TITLE
docs: Clarify related modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ tools.setCompleters([ queryAutoCompleter ]);
 
 ## Related
 
-- [`mongodb-js/ace-mode`](https://github.com/mongodb-js/ace-mode) MongoDB highlighting rules for ACE.
-- [`mongodb-js/ace-theme`](https://github.com/mongodb-js/ace-theme) MongoDB syntax highlighting rules for ACE.
+- [`mongodb-js/ace-mode`](https://github.com/mongodb-js/ace-mode) MongoDB highlighting rules for ACE Editor.
+- [`mongodb-js/ace-theme`](https://github.com/mongodb-js/ace-theme) CSS highlighting styles for multiline ACE Editor.
+- [`mongodb-js/ace-theme-query`](https://github.com/mongodb-js/ace-theme-query) CSS highlighting styles for ACE Editor as single line input.
 - [`mongodb-js/stage-validator`](https://github.com/mongodb-js/stage-validator) Aggregation Pipeline Stage grammar.
 
 ## Misc


### PR DESCRIPTION
## Description

- [`mongodb-js/ace-theme`](https://github.com/mongodb-js/ace-theme) is MongoDB *product* level reuse and is decoupled from mongodb *language* 
- [`mongodb-js/ace-mode`](https://github.com/mongodb-js/ace-mode) contains *language* definition
- Add [`mongodb-js/ace-theme-query`](https://github.com/mongodb-js/ace-theme-query) to related which is a fork of `mongodb-js/ace-theme` used by charts and compass query bars

### Checklist

- [x] Documentation is changed or added

## Motivation and Context

- [x] Misc

- Refining my thinking on [WRITING-4770](https://jira.mongodb.org/browse/WRITING-4770) and noticed this README was misleading.

## Related

- mongodb-js/ace-theme#2

## Types of changes

- [x] Docs-only
