### PR TITLE
Updated stage template for `$search`

### DIFF
--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -283,8 +283,8 @@ const STAGE_OPERATORS = [
     meta: 'stage',
     version: '4.1.11',
     description: 'Performs a full-text search on the specified field(s).',
-    comment: '/**\n * search: Analyzed search.\n * term: Unanalyzed search.\n * compound: Combines ops.\n * span: Find in text field regions.\n * exists: Test for presence of a field.\n * near: Find near number or date.\n * range: Find in numeric or date range.\n */\n',
-    snippet: '{\n  text: {\n    query: \'${1:string}\',\n    path: \'${2:string}\'\n  }\n}'
+    comment: '/** \n * index: the name of the Search index.\n * text: Analyzed search, with required fields of query and path, the analyzed field(s) to search.\n * term: Un-analyzed search.\n * compound: Combines ops.\n * span: Find in text field regions.\n * exists: Test for presence of a field.\n * near: Find near number or date.\n * range: Find in numeric or date range.\n */\n',
+    snippet: '{\n  index: \'${1:string}\',\n  text: {\n    query: \'${2:string}\',\n    path: \'${3:string}\'\n  }\n}'
   },
   {
     name: '$set',


### PR DESCRIPTION
COMPASS-4403: Include Index Parameter in `$search` template

## Description
Updates template for the `$search` aggregation stage.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
The template for the $search stage can be difficult to get started with because the index is missing from the template, yet it is still required. The name of the search index is defined at creation.

In the existing template, we were missing the `index` operator and we were still using the deprecated `search` operator, which is now replaced by `text`.

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
