### PR TITLE
fix(COMPASS-4492): remove sql pipeline stage operator

### DIFF
--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -335,18 +335,6 @@ const STAGE_OPERATORS = [
     snippet: '{\n  ${1:expression}\n}'
   },
   {
-    name: '$sql',
-    value: '$sql',
-    label: '$sql',
-    score: 1,
-    env: [ ADL ],
-    meta: 'stage',
-    version: '4.0.0', // always available in ADL
-    description: 'Executes a SQL statement against Atlas Data Lake.',
-    comment: '/**\n * statement: The SQL statement.\n * format: The SQL format.\n * formatVersion: The format version.\n */\n',
-    snippet: '{\n  statement: \'${1:statement}\',\n  format: \'${2:format}\',\n  formatVersion: ${3:formatVersion}\n}'
-  },
-  {
     name: '$unionWith',
     value: '$unionWith',
     label: '$unionWith',


### PR DESCRIPTION
COMPASS-4492

This PR removes `$sql` from the stage operators.

- [x] Patch (non-breaking change which fixes an issue)
