### PR TITLE
fix: add remaining 4.4 aggregation operators

### DIFF
--- a/lib/constants/expression-operators.js
+++ b/lib/constants/expression-operators.js
@@ -10,6 +10,13 @@ const EXPRESSION_OPERATORS = [
     version: '3.2.0'
   },
   {
+    name: '$accumulator',
+    value: '$accumulator',
+    score: 1,
+    meta: 'expr:arith',
+    version: '4.4.0'
+  },
+  {
     name: '$add',
     value: '$add',
     score: 1,
@@ -50,6 +57,20 @@ const EXPRESSION_OPERATORS = [
     score: 1,
     meta: 'expr:array',
     version: '3.4.4'
+  },
+  {
+    name: '$binarySize',
+    value: '$binarySize',
+    score: 1,
+    meta: 'expr:obj',
+    version: '4.4.0'
+  },
+  {
+    name: '$bsonSize',
+    value: '$bsonSize',
+    score: 1,
+    meta: 'expr:obj',
+    version: '4.4.0'
   },
   {
     name: '$ceil',
@@ -171,6 +192,13 @@ const EXPRESSION_OPERATORS = [
     version: '3.2.0'
   },
   {
+    name: '$first',
+    value: '$first',
+    score: 1,
+    meta: 'expr:array',
+    version: '4.4.0'
+  },
+  {
     name: '$floor',
     value: '$floor',
     score: 1,
@@ -248,6 +276,13 @@ const EXPRESSION_OPERATORS = [
     version: '3.2.0'
   },
   {
+    name: '$isNumber',
+    value: '$isNumber',
+    score: 1,
+    meta: 'expr:arith',
+    version: '4.4.0'
+  },
+  {
     name: '$isoDayOfWeek',
     value: '$isoDayOfWeek',
     score: 1,
@@ -267,6 +302,13 @@ const EXPRESSION_OPERATORS = [
     score: 1,
     meta: 'expr:date',
     version: '3.4.0'
+  },
+  {
+    name: '$last',
+    value: '$last',
+    score: 1,
+    meta: 'expr:array',
+    version: '4.4.0'
   },
   {
     name: '$let',
@@ -442,6 +484,20 @@ const EXPRESSION_OPERATORS = [
     score: 1,
     meta: 'expr:regex',
     version: '4.1.11'
+  },
+  {
+    name: '$replaceAll',
+    value: '$replaceAll',
+    score: 1,
+    meta: 'expr:string',
+    version: '4.4.0'
+  },
+  {
+    name: '$replaceOne',
+    value: '$replaceOne',
+    score: 1,
+    meta: 'expr:string',
+    version: '4.4.0'
   },
   {
     name: '$reverseArray',


### PR DESCRIPTION
→ https://docs.mongodb.com/manual/release-notes/4.4/#new-aggregation-operators

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
