### PR TITLE
fix(operators): Make lookup stage snippet not runnable on default COMPASS-3395

### DIFF
--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -236,11 +236,11 @@ const STAGE_OPERATORS = [
     version: '3.2.0',
     apiVersions: [1],
     description: 'Performs a join between two collections.',
-    comment: '/**\n * from: The target collection.\n * localField: The local join field.\n * foreignField: The target join field.\n * as: The name for the results.\n * pipeline: The pipeline to run on the joined collection.\n * let: Optional variables to use in the pipeline field stages.\n */\n',
-    snippet: '{\n  from: \'${1:string}\',\n' +
-    '  localField: \'${2:string}\',\n' +
-    '  foreignField: \'${3:string}\',\n' +
-    '  as: \'${4:string}\'\n}'
+    comment: '/**\n * from: The target collection.\n * localField: The local join field.\n * foreignField: The target join field.\n * as: The name for the results.\n * pipeline: Optional pipeline to run on the foreign collection.\n * let: Optional variables to use in the pipeline field stages.\n */\n',
+    snippet: '{\n  from: \'${1:collection}\',\n' +
+    '  localField: \'${2:field}\',\n' +
+    '  foreignField: \'${3:field}\',\n' +
+    '  as: \'${4:resultName}\'\n}'
   },
   {
     name: '$match',

--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -237,10 +237,10 @@ const STAGE_OPERATORS = [
     apiVersions: [1],
     description: 'Performs a join between two collections.',
     comment: '/**\n * from: The target collection.\n * localField: The local join field.\n * foreignField: The target join field.\n * as: The name for the results.\n * pipeline: Optional pipeline to run on the foreign collection.\n * let: Optional variables to use in the pipeline field stages.\n */\n',
-    snippet: '{\n  from: \'${1:collection}\',\n' +
-    '  localField: \'${2:field}\',\n' +
-    '  foreignField: \'${3:field}\',\n' +
-    '  as: \'${4:resultName}\'\n}'
+    snippet: '{\n  from: ${1:collection},\n' +
+    '  localField: ${2:field},\n' +
+    '  foreignField: ${3:field},\n' +
+    '  as: ${4:result}\n}'
   },
   {
     name: '$match',


### PR DESCRIPTION
COMPASS-3395

Before
<img width="494" alt="Screen Shot 2022-05-11 at 9 13 17 AM" src="https://user-images.githubusercontent.com/1791149/167858315-c3633070-77f3-4a12-9932-88fb3baa6810.png">


After
<img width="488" alt="Screen Shot 2022-05-11 at 9 20 49 AM" src="https://user-images.githubusercontent.com/1791149/167859856-c4d61c73-cce8-415a-9d18-cffd82c92152.png">
