### PR TITLE
fix: specify that $documents is dbOnly COMPASS-5843

### DIFF
--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -90,6 +90,7 @@ const STAGE_OPERATORS = [
     name: '$documents',
     value: '$documents',
     label: '$documents',
+    dbOnly: true,
     score: 1,
     env: [ ATLAS ],
     meta: 'stage',


### PR DESCRIPTION
With this compass, mongosh, vscode-extension, etc can filter out aggregation stage operators that won't work on collections if it knows the context.