### PR TITLE
fix: Have a separate template for $merge stage for ADL COMPASS-5901

### DIFF
--- a/lib/constants/stage-operators.js
+++ b/lib/constants/stage-operators.js
@@ -423,7 +423,7 @@ const STAGE_OPERATORS = [
     label: '$merge',
     outputStage: true,
     score: 1,
-    env: [ ATLAS, ADL, ON_PREM ],
+    env: [ ATLAS, ON_PREM ],
     meta: 'stage',
     version: '4.1.11',
     apiVersions: [1],
@@ -443,6 +443,41 @@ const STAGE_OPERATORS = [
   let: '\${3:specification(s)}',
   whenMatched: '\${4:string}',
   whenNotMatched: '\${5:string}'
+}`
+  },
+  {
+    name: '$merge',
+    value: '$merge',
+    label: '$merge',
+    outputStage: true,
+    score: 1,
+    env: [ ADL ],
+    meta: 'stage',
+    version: '4.0.0', // always available in ADL
+    apiVersions: [1],
+    namespaces: [ ...ANY_NAMESPACE ],
+    description: 'Merges the resulting documents into a collection, optionally overriding existing documents.',
+    comment: `/**
+ * atlas: Location to write the documents from the aggregation pipeline.
+ * on: Fields to identify.
+ * let: Defined variables.
+ * whenMatched: Action for matching docs.
+ * whenNotMatched: Action for non-matching docs.
+ */
+`,
+    snippet: `{
+  into: {
+    atlas: {
+      clusterName: '\${1:atlas-cluster-name}',
+      db: '\${2:database}',
+      coll: '\${3:collection}',
+      projectId: '\${4:optional-atlas-project-id}'
+    }
+  },
+  on: '\${5:identifier}',
+  let: { \${6:specification(s)} },
+  whenMatched: '\${7:string}',
+  whenNotMatched: '\${8:string}'
 }`
   },
   {


### PR DESCRIPTION
As reported [here](https://mongodb.slack.com/archives/CKNS6CS72/p1655391451217849?thread_ts=1655390024.231389&cid=CKNS6CS72), similar to $out, ADL has a different format for $merge, this patch provides this special template

COMPASS-5901